### PR TITLE
Remove node_modules/.bin prefix from install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pdf"
   ],
   "scripts": {
-    "install": "node_modules/.bin/node-pre-gyp install",
+    "install": "node-pre-gyp install",
     "test": "echo No test needed"
   },
   "binary": {


### PR DESCRIPTION
Hi! The `node_modules/.bin` prefix in the install script for this package is breaking our build on Windows! Here's the error message we're seeing:

```
Exit code: 1
Command: C:\WINDOWS\system32\cmd.exe
Arguments: /d /s /c node_modules/.bin/node-pre-gyp install
Directory: D:\[sanitized private directory info]\node_modules\canvas-prebuilt
Output: 'node_modules' is not recognized as an internal or external command,
operable program or batch file.
```

If you google that error message's output field, apparently this is a common thing for Windows folks using stuff from npm. The node_modules prefix isn't actually necessary, cos npm sorts all that business out for you automatically.